### PR TITLE
Fix: Correct property name for girosPorRepeticion

### DIFF
--- a/static/js/wheel.js
+++ b/static/js/wheel.js
@@ -209,11 +209,11 @@ function initApp() {
                     }
 
                     // Mostrar gráfico de evolución de capital
-                    if (results.evolucionCapital && results.giros_por_repeticion) {
+                    if (results.evolucionCapital && results.girosPorRepeticion) {
                         // Comprobar si hay datos de jugadores para mostrar
                         const playerNames = Object.keys(results.evolucionCapital);
                         if (playerNames.length > 0 && results.evolucionCapital[playerNames[0]].length > 0) {
-                             displayCapitalEvolutionChart(results.evolucionCapital, results.giros_por_repeticion);
+                             displayCapitalEvolutionChart(results.evolucionCapital, results.girosPorRepeticion);
                         } else {
                             // Manejar caso sin datos de evolución de capital (ej., limpiar gráfico anterior o mostrar mensaje)
                             if (capitalEvolutionChart) {


### PR DESCRIPTION
The "Evolución del Capital" chart was not displaying because of a mismatch in property names. The `ejecutarSimulacionMontecarlo` function in `montecarlo.js` returns an object with the property `girosPorRepeticion` (camelCase), while `wheel.js` was expecting `giros_por_repeticion` (snake_case) when checking the results and calling the display function.

This commit corrects the property name in `static/js/wheel.js` to `girosPorRepeticion` in the conditional statement and in the function call to `displayCapitalEvolutionChart`, allowing the chart to be displayed as intended.